### PR TITLE
Add attributes and send data from start

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
           key: node-cache-{{ checksum "package.json" }}
       - run: sudo npm install -g wct-istanbul
       - run: npm test
+      - run: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
   build:
     docker: *BUILDIMAGE

--- a/demo/src/rise-data-colors.html
+++ b/demo/src/rise-data-colors.html
@@ -42,7 +42,10 @@
 <script>
   function configureComponents() {
     const riseDataColors01 = document.querySelector('#rise-data-colors-01');
-    console.log('Rise components ready');
+
+    riseDataColors01.addEventListener( "data-update", evt => {
+      console.log( evt.detail );
+    } );
 
     // Uncomment if testing directly in browser
     // [ riseDataColors01 ].forEach( el => RisePlayerConfiguration.Helpers.sendStartEvent( el ) );

--- a/src/rise-data-colors.js
+++ b/src/rise-data-colors.js
@@ -1,28 +1,48 @@
 /* eslint-disable no-console, no-unused-vars */
 
-import { html } from "@polymer/polymer";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { version } from "./rise-data-colors-version.js";
 
 export default class RiseDataColors extends RiseElement {
 
-  static get template() {
-    // TODO: this is temporary for skeleton
-    return html`<h1>RISE DATE COLORS</h1>`;
-  }
-
   static get properties() {
-    return {};
+    return {
+      /**
+       * The base color. For example "rgba(235,235,235,1)"
+       */
+      base: {
+        type: String,
+        value: ""
+      },
+      /**
+       * The accent color. For example "rgba(125,125,125,1)"
+       */
+      accent: {
+        type: String,
+        value: ""
+      },
+      /**
+       * Determines whether to override Branding settings or not
+       */
+      override: {
+        type: Boolean,
+        value: false
+      }
+    };
   }
 
   // Each item of observers array is a method name followed by
   // a comma-separated list of one or more dependencies.
   static get observers() {
-    return [];
+    return [
+      "_reset(base, accent, override)"
+    ];
   }
 
   // Event name constants
-
+  static get EVENT_DATA_UPDATE() {
+    return "data-update";
+  }
 
   constructor() {
     super();
@@ -31,26 +51,18 @@ export default class RiseDataColors extends RiseElement {
     this._initialStart = true;
   }
 
-  ready() {
-    super.ready();
-
-    this.addEventListener( "rise-presentation-play", () => this._reset());
-    this.addEventListener( "rise-presentation-stop", () => this._stop());
-  }
-
   _reset() {
     if ( !this._initialStart ) {
-      this._stop();
       this._start();
     }
   }
 
-  _start() {
-    // TODO: coming soon
+  _sendColorsEvent( eventName, detail ) {
+    super._sendEvent( eventName, detail );
   }
 
-  _stop() {
-    // TODO: coming soon
+  _start() {
+    this._sendColorsEvent( RiseDataColors.EVENT_DATA_UPDATE, { base: this.base, accent: this.accent, override: this.override } );
   }
 
   _handleStart() {

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,10 @@
 <body>
 <script>
   // Load and run all tests (.html, .js):
-  WCT.loadSuites([]);
+  WCT.loadSuites([
+    "unit/rise-data-colors.html",
+    "integration/rise-data-colors.html"
+  ]);
 </script>
 </body>
 

--- a/test/integration/rise-data-colors.html
+++ b/test/integration/rise-data-colors.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+  <title>rise-data-colors test</title>
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+
+  <script type="text/javascript">
+    RisePlayerConfiguration = {
+      isConfigured: () => true
+    };
+  </script>
+
+  <script type="module" src="../../src/rise-data-colors.js"></script>
+</head>
+<body>
+<test-fixture id="test">
+  <template>
+    <rise-data-colors></rise-data-colors>
+  </template>
+</test-fixture>
+
+<script type="module">
+  suite("rise-data-colors", () => {
+    let sandbox = sinon.createSandbox();
+    let element, clock;
+
+    setup(() => {
+      RisePlayerConfiguration.Logger = {
+        info: () => {},
+        warning: () => {},
+        error: () => {}
+      };
+
+      RisePlayerConfiguration.isPreview = () => {
+        return false;
+      };
+
+      clock = sinon.useFakeTimers();
+
+      element = fixture("test");
+    });
+
+    teardown(()=>{
+      sandbox.restore();
+      clock.restore();
+    });
+
+    suite( "data event", () => {
+      test( "should receive data event immediately after component starts", (done) => {
+        const handler = function( evt ) {
+          assert.isObject( evt.detail );
+          assert.equal( evt.detail.override, false );
+          assert.equal( evt.detail.base, "" );
+          assert.equal( evt.detail.accent, "" );
+
+          done();
+        };
+
+        element.addEventListener( "data-update", handler );
+        element.dispatchEvent( new CustomEvent( "start" ) );
+      } );
+
+    } );
+
+  });
+</script>
+</body>
+</html>

--- a/test/unit/rise-data-colors.html
+++ b/test/unit/rise-data-colors.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+  <title>rise-data-colors test</title>
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+
+  <script type="text/javascript">
+    RisePlayerConfiguration = {
+      isConfigured: () => true
+    };
+  </script>
+
+  <script type="module" src="../../src/rise-data-colors.js"></script>
+</head>
+<body>
+<test-fixture id="test-block">
+  <template>
+    <rise-data-colors></rise-data-colors>
+  </template>
+</test-fixture>
+
+<script type="module">
+  suite("rise-data-colors", () => {
+    let sandbox = sinon.createSandbox();
+    let element, clock, riseElement;
+
+    setup(() => {
+      RisePlayerConfiguration.isPreview = () => {
+        return false;
+      };
+
+      RisePlayerConfiguration.Logger = {
+        info: () => {},
+        warning: () => {},
+        error: sinon.spy()
+      };
+
+      clock = sinon.useFakeTimers();
+
+      element = fixture("test-block");
+
+      riseElement = element.__proto__.__proto__;
+
+      sandbox.spy(riseElement, '_sendEvent');
+      sandbox.stub(riseElement, '_setUptimeError');
+      sandbox.stub(riseElement, 'log');
+    });
+
+    teardown(()=>{
+      sandbox.restore();
+      clock.restore();
+    });
+
+    suite("properties", () => {
+      test("should set default for override", () => {
+        assert.equal(element.override, false);
+      });
+    });
+
+    suite( "_reset", () => {
+      setup( () => {
+        sandbox.stub( element, "_start" );
+      } );
+
+      test( "should not execute reset when an initial start still pending", () => {
+        element._reset();
+
+        assert.isFalse( element._start.calledOnce );
+      } );
+
+      test( "should execute reset when not the initial start", () => {
+        element._initialStart = false;
+        element._reset();
+
+        assert.isTrue( element._start.calledOnce );
+      } );
+    } );
+
+    suite( "_start", () => {
+
+      test( "should send data-update event", ( done ) => {
+        const listener = ( evt ) => {
+          assert.deepEqual( evt.detail, {
+            base: element.base,
+            accent: element.accent,
+            override: false
+          } );
+
+          element.removeEventListener( "data-update", listener );
+          done();
+        };
+
+        element.addEventListener( "data-update", listener );
+        element.base = "rgba(235,235,235,1)";
+        element.accent = "rgba(125,125,125,1)";
+        element._start();
+      } );
+
+    } );
+
+    suite( "_handleStart", () => {
+
+      setup( () => {
+        sandbox.stub( element, "_start" );
+      } );
+
+      test( "should call _start() when this is the initial 'start'", () => {
+        const event = new CustomEvent( "start" );
+        element.dispatchEvent( event );
+
+        assert.isTrue( element._start.calledOnce );
+        assert.isFalse( element._initialStart, "_initialStart set to false" );
+      } );
+
+      test( "should not call _start() when this is not the initial start", () => {
+        element._initialStart = false;
+
+        const event = new CustomEvent( "start" );
+        element.dispatchEvent( event );
+
+        assert.isFalse( element._start.called );
+      } );
+
+    } );
+
+    suite( "_sendThemeEvent", () => {
+      test( "should process event to be sent", () => {
+        element._sendColorsEvent( 'data-update', 'test' );
+
+        assert.isTrue( riseElement._sendEvent.calledWith( 'data-update', 'test' ) );
+      } );
+    } );
+
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Description
Add `base`, `accent`, and `override` attributes and handle observing them

Remove listening for Viewer _play_ and _stop_ events as they are not required to handle in this component

Stop listening for Viewer events and 

## Motivation and Context
Component development

## How Has This Been Tested?
Tested locally via Charles and Apps staging:

https://apps-stage-8.risevision.com/templates/edit/ab1abbc8-b625-49e4-9220-e2297f0ce193/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
